### PR TITLE
optional exceptions; add guarded __builtin_expect to find_impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries("${TEST_EXECUTABLE}" ${Boost_LIBRARIES})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options("${TEST_EXECUTABLE}" PRIVATE -std=c++11 -Werror -Wall -Wextra -Wold-style-cast -O3 -DTSL_DEBUG)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    target_compile_options("${TEST_EXECUTABLE}" PRIVATE /WX /W3 /DTSL_DEBUG)
+    target_compile_options("${TEST_EXECUTABLE}" PRIVATE /WX /W3 /DTSL_DEBUG /D__EXCEPTIONS)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries("${TEST_EXECUTABLE}" ${Boost_LIBRARIES})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options("${TEST_EXECUTABLE}" PRIVATE -std=c++11 -Werror -Wall -Wextra -Wold-style-cast -O3 -DTSL_DEBUG)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    target_compile_options("${TEST_EXECUTABLE}" PRIVATE /WX /W3 /DTSL_DEBUG /D__EXCEPTIONS)
+    target_compile_options("${TEST_EXECUTABLE}" PRIVATE /WX /W3 /DTSL_DEBUG)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A **benchmark** of `tsl::robin_map` against other hash maps may be found [here](
 - No need to reserve any sentinel value from the keys.
 - Possibility to store the hash value alongside the stored key-value for faster rehash and lookup if the hash or the key equal functions are expensive to compute. Note that hash may be stored even if not asked explicitly when the library can detect that it will have no impact on the size of the structure in memory due to alignment. See the [StoreHash](https://tessil.github.io/robin-map/classtsl_1_1robin__map.html#details) template parameter for details.
 - If the hash is known before a lookup, it is possible to pass it as parameter to speed-up the lookup.
+- The library can be used with exceptions disabled (through `-fno-exceptions` option on Clang and GCC, without an `/EH` option on MSVC or simply by defining `TSL_NO_EXCEPTIONS`). `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.
 - API closely similar to `std::unordered_map` and `std::unordered_set`.
 
 ### Differences compare to `std::unordered_map`

--- a/tsl/robin_growth_policy.h
+++ b/tsl/robin_growth_policy.h
@@ -55,7 +55,7 @@
 #        ifdef NDEBUG
 #            define TSL_THROW_OR_TERMINATE(ex, msg) std::terminate()
 #        else
-#            include<cstdio>
+#            include <cstdio>
 #            define TSL_THROW_OR_TERMINATE(ex, msg) do { std::fprintf(stderr, msg); std::terminate(); } while(0)
 #        endif
 #    endif

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -498,7 +498,7 @@ public:
                                        m_grow_on_next_insert(false)
     {
         if(bucket_count > max_bucket_count()) {
-            throw std::length_error("The map exceeds its maxmimum size.");
+            THROW(std::length_error, "The map exceeds its maxmimum size.");
         }
         
         /*
@@ -844,7 +844,7 @@ public:
             return it.value();
         }
         else {
-            throw std::out_of_range("Couldn't find key.");
+            THROW(std::out_of_range, "Couldn't find key.");
         }
     }
     
@@ -1013,8 +1013,8 @@ private:
         distance_type dist_from_ideal_bucket = 0;
         
         while(dist_from_ideal_bucket <= m_buckets[ibucket].dist_from_ideal_bucket()) {
-            if((!USE_STORED_HASH_ON_LOOKUP || m_buckets[ibucket].bucket_hash_equal(hash)) && 
-               compare_keys(KeySelect()(m_buckets[ibucket].value()), key)) 
+            if (TSL_LIKELY((!USE_STORED_HASH_ON_LOOKUP || m_buckets[ibucket].bucket_hash_equal(hash)) &&
+               compare_keys(KeySelect()(m_buckets[ibucket].value()), key)))
             {
                 return const_iterator(m_buckets.begin() + ibucket);
             }

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -42,17 +42,6 @@
 #include "robin_growth_policy.h"
 
 
-
-#ifndef tsl_assert
-    #ifdef TSL_DEBUG
-    #define tsl_assert(expr) assert(expr)
-    #else
-    #define tsl_assert(expr) (static_cast<void>(0))
-    #endif
-#endif
-
-
-
 namespace tsl {
     
 namespace detail_robin_hash {
@@ -507,7 +496,7 @@ public:
                                        m_grow_on_next_insert(false)
     {
         if(bucket_count > max_bucket_count()) {
-            THROW(std::length_error, "The map exceeds its maxmimum size.");
+            TSL_THROW_OR_TERMINATE(std::length_error, "The map exceeds its maxmimum size.");
         }
         
         if(m_bucket_count > 0) {
@@ -892,7 +881,7 @@ public:
             return it.value();
         }
         else {
-            THROW(std::out_of_range, "Couldn't find key.");
+            TSL_THROW_OR_TERMINATE(std::out_of_range, "Couldn't find key.");
         }
     }
     


### PR DESCRIPTION
Hello!  These changes allow us to use robin-map in contexts where exception throwing is not allowed; figured the changes are broadly useful