### PR TITLE
Bug correction, set a moved hash map/set in a valid state so that it can still be used even after a move

### DIFF
--- a/tests/policy_tests.cpp
+++ b/tests/policy_tests.cpp
@@ -49,15 +49,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_policy, Policy, test_types) {
     std::size_t bucket_count = 0;
     Policy policy(bucket_count);
     
+    BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+    BOOST_CHECK_EQUAL(bucket_count, 0);
+    
     try {
         while(true) {
+            const std::size_t previous_bucket_count = bucket_count;
+            
             bucket_count = policy.next_bucket_count();
             policy = Policy(bucket_count);
+            
+            BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+            BOOST_CHECK(bucket_count > previous_bucket_count);
         }
     }
     catch(const std::length_error& ) {
         exception_thrown = true;
-        BOOST_CHECK_EQUAL(bucket_count, policy.max_bucket_count());
     }
     
     BOOST_CHECK(exception_thrown);

--- a/tests/robin_map_tests.cpp
+++ b/tests/robin_map_tests.cpp
@@ -83,7 +83,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert, HMap, test_types) {
     using key_t = typename HMap::key_type; using value_t = typename HMap:: mapped_type;
     
     const std::size_t nb_values = 1000;
-    HMap map;
+    HMap map(0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    
     typename HMap::iterator it;
     bool inserted;
     
@@ -651,6 +653,49 @@ BOOST_AUTO_TEST_CASE(test_copy_constructor_operator) {
     BOOST_CHECK(map_copy == map_copy3);
 }
 
+BOOST_AUTO_TEST_CASE(test_use_after_move_constructor) {
+    using HMap = tsl::robin_map<std::string, move_only_test>;
+    
+    const std::size_t nb_values = 100;
+    HMap map = utils::get_filled_hash_map<HMap>(nb_values);
+    HMap map_move(std::move(map));
+    
+    
+    BOOST_CHECK(map == (HMap()));
+    BOOST_CHECK_EQUAL(map.size(), 0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    BOOST_CHECK_EQUAL(map.erase("a"), 0);
+    BOOST_CHECK(map.find("a") == map.end());
+    
+    for(std::size_t i = 0; i < nb_values; i++) {
+        map.insert({utils::get_key<std::string>(i), utils::get_value<move_only_test>(i)});
+    }
+    
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+    BOOST_CHECK(map == map_move);
+}
+
+BOOST_AUTO_TEST_CASE(test_use_after_move_operator) {
+    using HMap = tsl::robin_map<std::string, move_only_test>;
+    
+    const std::size_t nb_values = 100;
+    HMap map = utils::get_filled_hash_map<HMap>(nb_values);
+    HMap map_move = std::move(map);
+    
+    
+    BOOST_CHECK(map == (HMap()));
+    BOOST_CHECK_EQUAL(map.size(), 0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    BOOST_CHECK_EQUAL(map.erase("a"), 0);
+    BOOST_CHECK(map.find("a") == map.end());
+    
+    for(std::size_t i = 0; i < nb_values; i++) {
+        map.insert({utils::get_key<std::string>(i), utils::get_value<move_only_test>(i)});
+    }
+    
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+    BOOST_CHECK(map == map_move);
+}
 
 
 /**
@@ -807,6 +852,7 @@ BOOST_AUTO_TEST_CASE(test_heterogeneous_lookups) {
 BOOST_AUTO_TEST_CASE(test_empty_map) {
     tsl::robin_map<std::string, int> map(0);
     
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
     BOOST_CHECK_EQUAL(map.size(), 0);
     BOOST_CHECK(map.empty());
     

--- a/tsl/robin_growth_policy.h
+++ b/tsl/robin_growth_policy.h
@@ -51,22 +51,27 @@ public:
     /**
      * Called on the hash table creation and on rehash. The number of buckets for the table is passed in parameter.
      * This number is a minimum, the policy may update this value with a higher value if needed (but not lower).
+     *
+     * If 0 is given, min_bucket_count_in_out must still be 0 after the policy creation and
+     * bucket_for_hash must always return 0 in this case.
      */
-    power_of_two_growth_policy(std::size_t& min_bucket_count_in_out) {
+    explicit power_of_two_growth_policy(std::size_t& min_bucket_count_in_out) {
         if(min_bucket_count_in_out > max_bucket_count()) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        static_assert(MIN_BUCKETS_SIZE > 0, "MIN_BUCKETS_SIZE must be > 0.");
-        const std::size_t min_bucket_count = MIN_BUCKETS_SIZE;
-        
-        min_bucket_count_in_out = std::max(min_bucket_count, min_bucket_count_in_out);
-        min_bucket_count_in_out = round_up_to_power_of_two(min_bucket_count_in_out);
-        m_mask = min_bucket_count_in_out - 1;
+        if(min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out = round_up_to_power_of_two(min_bucket_count_in_out);
+            m_mask = min_bucket_count_in_out - 1;
+        }
+        else {
+            m_mask = 0;
+        }
     }
     
     /**
-     * Return the bucket [0, bucket_count()) to which the hash belongs.
+     * Return the bucket [0, bucket_count()) to which the hash belongs. 
+     * If bucket_count() is 0, it must always return 0.
      */
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
         return hash & m_mask;
@@ -89,6 +94,14 @@ public:
     std::size_t max_bucket_count() const {
         // Largest power of two.
         return (std::numeric_limits<std::size_t>::max() / 2) + 1;
+    }
+    
+    /**
+     * Reset the growth policy as if it was created with a bucket count of 0.
+     * After a clear, the policy must always return 0 when bucket_for_hash is called.
+     */
+    void clear() noexcept {
+        m_mask = 0;
     }
     
 private:
@@ -114,7 +127,6 @@ private:
     }
     
 protected:
-    static const std::size_t MIN_BUCKETS_SIZE = 2;
     static_assert(is_power_of_two(GrowthFactor) && GrowthFactor >= 2, "GrowthFactor must be a power of two >= 2.");
     
     std::size_t m_mask;
@@ -123,33 +135,34 @@ protected:
 
 /**
  * Grow the hash table by GrowthFactor::num / GrowthFactor::den and use a modulo to map a hash
- * to a bucket. Slower but it can be usefull if you want a slower growth.
+ * to a bucket. Slower but it can be useful if you want a slower growth.
  */
 template<class GrowthFactor = std::ratio<3, 2>>
 class mod_growth_policy {
 public:
-    mod_growth_policy(std::size_t& min_bucket_count_in_out) {
+    explicit mod_growth_policy(std::size_t& min_bucket_count_in_out) {
         if(min_bucket_count_in_out > max_bucket_count()) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        static_assert(MIN_BUCKETS_SIZE > 0, "MIN_BUCKETS_SIZE must be > 0.");
-        const std::size_t min_bucket_count = MIN_BUCKETS_SIZE;
-        
-        min_bucket_count_in_out = std::max(min_bucket_count, min_bucket_count_in_out);
-        m_bucket_count = min_bucket_count_in_out;
+        if(min_bucket_count_in_out > 0) {
+            m_mod = min_bucket_count_in_out;
+        }
+        else {
+            m_mod = 1;
+        }
     }
     
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
-        return hash % m_bucket_count;
+        return hash % m_mod;
     }
     
     std::size_t next_bucket_count() const {
-        if(m_bucket_count == max_bucket_count()) {
+        if(m_mod == max_bucket_count()) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        const double next_bucket_count = std::ceil(double(m_bucket_count) * REHASH_SIZE_MULTIPLICATION_FACTOR);
+        const double next_bucket_count = std::ceil(double(m_mod) * REHASH_SIZE_MULTIPLICATION_FACTOR);
         if(!std::isnormal(next_bucket_count)) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
@@ -166,8 +179,11 @@ public:
         return MAX_BUCKET_COUNT;
     }
     
+    void clear() noexcept {
+        m_mod = 1;
+    }
+    
 private:
-    static const std::size_t MIN_BUCKETS_SIZE = 2;
     static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR = 1.0 * GrowthFactor::num / GrowthFactor::den;
     static const std::size_t MAX_BUCKET_COUNT = 
             std::size_t(double(
@@ -176,18 +192,18 @@ private:
             
     static_assert(REHASH_SIZE_MULTIPLICATION_FACTOR >= 1.1, "Growth factor should be >= 1.1.");
     
-    std::size_t m_bucket_count;
+    std::size_t m_mod;
 };
 
 
 
 namespace detail {
 
-static constexpr const std::array<std::size_t, 39> PRIMES = {{
-    5ul, 17ul, 29ul, 37ul, 53ul, 67ul, 79ul, 97ul, 131ul, 193ul, 257ul, 389ul, 521ul, 769ul, 1031ul, 1543ul, 2053ul, 
-    3079ul, 6151ul, 12289ul, 24593ul, 49157ul, 98317ul, 196613ul, 393241ul, 786433ul, 1572869ul, 3145739ul, 
-    6291469ul, 12582917ul, 25165843ul, 50331653ul, 100663319ul, 201326611ul, 402653189ul, 805306457ul, 
-    1610612741ul, 3221225473ul, 4294967291ul
+static constexpr const std::array<std::size_t, 40> PRIMES = {{
+    1ul, 5ul, 17ul, 29ul, 37ul, 53ul, 67ul, 79ul, 97ul, 131ul, 193ul, 257ul, 389ul, 521ul, 769ul, 1031ul, 
+    1543ul, 2053ul, 3079ul, 6151ul, 12289ul, 24593ul, 49157ul, 98317ul, 196613ul, 393241ul, 786433ul, 
+    1572869ul, 3145739ul, 6291469ul, 12582917ul, 25165843ul, 50331653ul, 100663319ul, 201326611ul, 
+    402653189ul, 805306457ul, 1610612741ul, 3221225473ul, 4294967291ul
 }};
 
 template<unsigned int IPrime>
@@ -195,11 +211,11 @@ static constexpr std::size_t mod(std::size_t hash) { return hash % PRIMES[IPrime
 
 // MOD_PRIME[iprime](hash) returns hash % PRIMES[iprime]. This table allows for faster modulo as the
 // compiler can optimize the modulo code better with a constant known at the compilation.
-static constexpr const std::array<std::size_t(*)(std::size_t), 39> MOD_PRIME = {{ 
+static constexpr const std::array<std::size_t(*)(std::size_t), 40> MOD_PRIME = {{ 
     &mod<0>, &mod<1>, &mod<2>, &mod<3>, &mod<4>, &mod<5>, &mod<6>, &mod<7>, &mod<8>, &mod<9>, &mod<10>, 
     &mod<11>, &mod<12>, &mod<13>, &mod<14>, &mod<15>, &mod<16>, &mod<17>, &mod<18>, &mod<19>, &mod<20>, 
     &mod<21>, &mod<22>, &mod<23>, &mod<24>, &mod<25>, &mod<26>, &mod<27>, &mod<28>, &mod<29>, &mod<30>, 
-    &mod<31>, &mod<32>, &mod<33>, &mod<34>, &mod<35>, &mod<36>, &mod<37> , &mod<38>
+    &mod<31>, &mod<32>, &mod<33>, &mod<34>, &mod<35>, &mod<36>, &mod<37> , &mod<38>, &mod<39>
 }};
 
 }
@@ -230,7 +246,7 @@ static constexpr const std::array<std::size_t(*)(std::size_t), 39> MOD_PRIME = {
  */
 class prime_growth_policy {
 public:
-    prime_growth_policy(std::size_t& min_bucket_count_in_out) {
+    explicit prime_growth_policy(std::size_t& min_bucket_count_in_out) {
         auto it_prime = std::lower_bound(detail::PRIMES.begin(), 
                                          detail::PRIMES.end(), min_bucket_count_in_out);
         if(it_prime == detail::PRIMES.end()) {
@@ -238,7 +254,12 @@ public:
         }
         
         m_iprime = static_cast<unsigned int>(std::distance(detail::PRIMES.begin(), it_prime));
-        min_bucket_count_in_out = *it_prime;
+        if(min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out = *it_prime;
+        }
+        else {
+            min_bucket_count_in_out = 0;
+        }
     }
     
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
@@ -255,6 +276,10 @@ public:
     
     std::size_t max_bucket_count() const {
         return detail::PRIMES.back();
+    }
+    
+    void clear() noexcept {
+        m_iprime = 0;
     }
     
 private:

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -325,7 +325,9 @@ private:
     template<typename U>
     using has_mapped_type = typename std::integral_constant<bool, !std::is_same<U, void>::value>;
     
-
+    static_assert(noexcept(std::declval<GrowthPolicy>().bucket_for_hash(std::size_t(0))), "GrowthPolicy::bucket_for_hash must be noexcept.");
+    static_assert(noexcept(std::declval<GrowthPolicy>().clear()), "GrowthPolicy::clear must be noexcept.");
+    
 public:
     template<bool IsConst>
     class robin_iterator;


### PR DESCRIPTION
Correct moved state, a moved `tsl::robin_map` or `tsl::robin_set` can now still be used after a move. Previously the map ended up in a invalid state after a move but the standard mandates that a moved object should be in a valid (but unspecified) state so that it can still be used after a move.

The following code will now work:
```c++
tsl::robin_set<int> set = {0, 1, 2, 3, 4};
tsl::robin_set<int> set2 = std::move(set);
    
set.erase(0);
set.find(0);
set.insert(0);
```