### PR TITLE
Fix issue #6 by circumverting a bug in MSVC on insert when using a pointer as type in a set

### DIFF
--- a/tests/robin_set_tests.cpp
+++ b/tests/robin_set_tests.cpp
@@ -117,5 +117,16 @@ BOOST_AUTO_TEST_CASE(test_compare) {
     BOOST_CHECK(set3_1 != set2_1);
 }
 
+BOOST_AUTO_TEST_CASE(test_insert_pointer) {
+    // Test added mainly to be sure that the code compiles with MSVC due to a bug in the compiler
+    std::string value;
+    std::string* value_ptr = &value;
+
+    tsl::robin_set<std::string*> set;
+    set.insert(value_ptr);
+
+    BOOST_CHECK_EQUAL(set.size(), 1);
+    BOOST_CHECK_EQUAL(**set.begin(), value);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/robin_set_tests.cpp
+++ b/tests/robin_set_tests.cpp
@@ -118,7 +118,8 @@ BOOST_AUTO_TEST_CASE(test_compare) {
 }
 
 BOOST_AUTO_TEST_CASE(test_insert_pointer) {
-    // Test added mainly to be sure that the code compiles with MSVC due to a bug in the compiler
+    // Test added mainly to be sure that the code compiles with MSVC due to a bug in the compiler.
+    // See robin_hash::insert_value_impl for details.
     std::string value;
     std::string* value_ptr = &value;
 

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -1148,7 +1148,8 @@ private:
     void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket, 
                       truncated_hash_type hash, Args&&... value_type_args) 
     {
-        insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value_type(std::forward<Args>(value_type_args)...));
+        value_type value(std::forward<Args>(value_type_args)...);
+        insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
     }
 
     void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -1158,8 +1158,13 @@ private:
         insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
     }
 
-    // We don't use value_type&& value as last argument due to a bug in MSVC,
-    // but the value will be in a moved state at the end of the function.
+    /*
+     * We don't use `value_type&& value` as last argument due to a bug in MSVC when `value_type` is a pointer,
+     * The compiler is not able to see the difference between `std::string*` and `std::string*&&` resulting in 
+     * compile error.
+     * 
+     * The `value` will be in a moved state at the end of the function.
+     */
     void insert_value_impl(std::size_t ibucket, distance_type dist_from_ideal_bucket,
                            truncated_hash_type hash, value_type& value)
     {

--- a/tsl/robin_hash.h
+++ b/tsl/robin_hash.h
@@ -1148,11 +1148,19 @@ private:
     void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket, 
                       truncated_hash_type hash, Args&&... value_type_args) 
     {
-        insert_value(ibucket, dist_from_ideal_bucket, hash, value_type(std::forward<Args>(value_type_args)...));
+        insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value_type(std::forward<Args>(value_type_args)...));
     }
 
-    void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket, 
-                      truncated_hash_type hash, value_type&& value) 
+    void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                      truncated_hash_type hash, value_type&& value)
+    {
+        insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
+    }
+
+    // We don't use value_type&& value as last argument due to a bug in MSVC,
+    // but the value will be in a moved state at the end of the function.
+    void insert_value_impl(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                           truncated_hash_type hash, value_type& value)
     {
         m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket, hash, value);
         ibucket = next_bucket(ibucket);


### PR DESCRIPTION
The PR fixes the issue #6 due to a bug in MSVC when `/permissive-` is not used. Using a pointer in a `tsl::robin_set` could result in an infinite recursion between the `insert_value` functions as by default MSVC doesn't make any distinction between `type*` and `type*&&`.