### PR TITLE
Fix compilation error for move-only types with a throwing move constructor/operator.

### DIFF
--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -489,8 +489,8 @@ public:
                float max_load_factor): Hash(hash), 
                                        KeyEqual(equal),
                                        GrowthPolicy(bucket_count),
-                                       m_buckets_data(alloc), 
-                                       m_buckets(static_empty_bucket_ptr()), 
+                                       m_buckets_data(bucket_count, alloc),
+                                       m_buckets(m_buckets_data.empty()?static_empty_bucket_ptr():m_buckets_data.data()),
                                        m_bucket_count(bucket_count),
                                        m_nb_elements(0), 
                                        m_grow_on_next_insert(false)
@@ -500,17 +500,6 @@ public:
         }
         
         if(m_bucket_count > 0) {
-            /*
-            * We can't use the `vector(size_type count, const Allocator& alloc)` constructor
-            * as it's only available in C++14 and we need to support C++11. We thus must resize after using
-            * the `vector(const Allocator& alloc)` constructor.
-            * 
-            * We can't use `vector(size_type count, const T& value, const Allocator& alloc)` as it requires the
-            * value T to be copyable.
-            */
-            m_buckets_data.resize(m_bucket_count);
-            m_buckets = m_buckets_data.data();
-            
             tsl_rh_assert(!m_buckets_data.empty());
             m_buckets_data.back().set_as_last_bucket();
         }

--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -489,6 +489,7 @@ public:
 
     
 public:
+#if defined(__cplusplus) && __cplusplus >= 201402L
     robin_hash(size_type bucket_count, 
                const Hash& hash,
                const KeyEqual& equal,
@@ -496,8 +497,43 @@ public:
                float max_load_factor): Hash(hash), 
                                        KeyEqual(equal),
                                        GrowthPolicy(bucket_count),
-                                       m_buckets_data(bucket_count, alloc),
+                                       m_buckets_data(
+                                           ((bucket_count > max_bucket_count())?
+                                               TSL_RH_THROW_OR_TERMINATE(std::length_error, "The map exceeds its maxmimum bucket count."):
+                                               bucket_count), 
+                                           alloc
+                                       ),
                                        m_buckets(m_buckets_data.empty()?static_empty_bucket_ptr():m_buckets_data.data()),
+                                       m_bucket_count(bucket_count),
+                                       m_nb_elements(0), 
+                                       m_grow_on_next_insert(false)
+    {
+        if(m_bucket_count > 0) {
+            tsl_rh_assert(!m_buckets_data.empty());
+            m_buckets_data.back().set_as_last_bucket();
+        }
+        
+        
+        this->max_load_factor(max_load_factor);
+    }
+#else
+    /**
+     * C++11 doesn't support the creation of a std::vector with a custom allocator and 'count' default-inserted elements. 
+     * The needed contructor `explicit vector(size_type count, const Allocator& alloc = Allocator());` is only
+     * available in C++14 and later. We thus must resize after using the `vector(const Allocator& alloc)` constructor.
+     * 
+     * We can't use `vector(size_type count, const T& value, const Allocator& alloc)` as it requires the
+     * value T to be copyable.
+     */
+    robin_hash(size_type bucket_count, 
+               const Hash& hash,
+               const KeyEqual& equal,
+               const Allocator& alloc,
+               float max_load_factor): Hash(hash), 
+                                       KeyEqual(equal),
+                                       GrowthPolicy(bucket_count),
+                                       m_buckets_data(alloc), 
+                                       m_buckets(static_empty_bucket_ptr()), 
                                        m_bucket_count(bucket_count),
                                        m_nb_elements(0), 
                                        m_grow_on_next_insert(false)
@@ -507,6 +543,9 @@ public:
         }
         
         if(m_bucket_count > 0) {
+            m_buckets_data.resize(m_bucket_count);
+            m_buckets = m_buckets_data.data();
+            
             tsl_rh_assert(!m_buckets_data.empty());
             m_buckets_data.back().set_as_last_bucket();
         }
@@ -514,6 +553,7 @@ public:
         
         this->max_load_factor(max_load_factor);
     }
+#endif
     
     robin_hash(const robin_hash& other): Hash(other),
                                          KeyEqual(other),


### PR DESCRIPTION
This PR fix issue #10 . The fix is only valid for C++14 compilers and later. The compile error will remain with C++11 and move-only types that have a move constructor/operator that are throwable.

A C++11 compatible fix may arrive later. It requires to replace the `std::vector<bucket_entry> m_buckets_data` and `bucket_entry* m_buckets` variables with a `bucket_entry* m_buckets` and `size_type m_bucket_count` variable and manage the `Allocator` manually. This could reduce the `sizeof(robin_hash)` by `2*sizeof(void*)`.