### PR TITLE
Allow find to work on all comparable keys

### DIFF
--- a/include/tsl/robin_map.h
+++ b/include/tsl/robin_map.h
@@ -484,8 +484,8 @@ public:
     
     
     
-    
-    iterator find(const Key& key) { return m_ht.find(key); }
+    template<class SimilarToKey>
+    iterator find(const SimilarToKey& key) { return m_ht.find(key); }
     
     /**
      * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same

--- a/include/tsl/robin_set.h
+++ b/include/tsl/robin_set.h
@@ -355,8 +355,8 @@ public:
     
     
     
-    
-    iterator find(const Key& key) { return m_ht.find(key); }
+    template<class SimilarToKey>
+    iterator find(const SimilarToKey& key) { return m_ht.find(key); }
     
     /**
      * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same


### PR DESCRIPTION
This fork allows scenarios as follows:

```cpp
struct PtrIntHasher
{
  std::size_t operator()(const std::unique_ptr<std::size_t>& p) const
  { assert(p); return *p; }
  std::size_t operator()(const std::size_t* p) const
  { assert(p); return *p; }
};

struct PtrIntComparator
{
  bool operator()(const std::unique_ptr<std::size_t>& lhs, std::unique_ptr<std::size_t>& rhs) const
  { return (*this)(lhs.get(), rhs.get()); }

  bool operator()(const std::unique_ptr<std::size_t>& lhs, const std::size_t* rhs) const
  { return (*this)(lhs.get(), rhs); }

  bool operator()(const std::size_t* lhs, const std::unique_ptr<std::size_t>& rhs) const
  { return (*this)(lhs, rhs.get()); }

  bool operator()(const std::size_t* lhs, const std::size_t* rhs) const
  { assert(lhs && rhs); return lhs == rhs; }
};

tsl::robin_set<std::unique_ptr<std::size_t>, PtrIntHasher, PtrIntComparator> set;

const std::size_t* frtytw = set.emplace(std::make_unique<std::size_t>(42)).first->get();

if(set.find(frtytw) == set.end())
  fmt::print("yes\n");
else
  fmt::print("no\n");
```

Since `robin_hash` is already quite generic, code changes are minimal.