### PR TITLE
Add support for efficient serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A **benchmark** of `tsl::robin_map` against other hash maps may be found [here](
 - No need to reserve any sentinel value from the keys.
 - Possibility to store the hash value alongside the stored key-value for faster rehash and lookup if the hash or the key equal functions are expensive to compute. Note that hash may be stored even if not asked explicitly when the library can detect that it will have no impact on the size of the structure in memory due to alignment. See the [StoreHash](https://tessil.github.io/robin-map/classtsl_1_1robin__map.html#details) template parameter for details.
 - If the hash is known before a lookup, it is possible to pass it as parameter to speed-up the lookup (see `precalculated_hash` parameter in [API](https://tessil.github.io/robin-map/classtsl_1_1robin__map.html#a35021b11aabb61820236692a54b3a0f8)).
+- Support for efficient serialization and deserialization (see [example](#serialization) and the `serialize/deserialize` methods in the [API](https://tessil.github.io/robin-map/classtsl_1_1robin__map.html) for details).
 - The library can be used with exceptions disabled (through `-fno-exceptions` option on Clang and GCC, without an `/EH` option on MSVC or simply by defining `TSL_NO_EXCEPTIONS`). `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.
 - API closely similar to `std::unordered_map` and `std::unordered_set`.
 
@@ -275,6 +276,207 @@ int main() {
 ```
 
 
+#### Serialization
+
+The library provides an efficient way to serialize and deserialize a map or a set so that it can be saved to a file or send through the network.
+To do so, it requires the user to provide a function object for both serialization and deserialization.
+
+```c++
+struct serializer {
+    // Must support the following types for U: std::int16_t, `std::uint32_t, 
+    // std::uint64_t, float and std::pair<Key, T> if a map is used or Key for 
+    // a set.
+    template<typename U>
+    void operator()(const U& value);
+};
+```
+
+```c++
+struct deserializer {
+    // Must support the following types for U: std::int16_t, `std::uint32_t, 
+    // std::uint64_t, float and std::pair<Key, T> if a map is used or Key for 
+    // a set.
+    template<typename U>
+    U operator()();
+};
+```
+
+Note that the implementation leaves binary compatibility (endianness, float binary representation, size of int, ...) of the types it serializes/deserializes in the hands of the provided function objects if compatibility is required.
+
+More details regarding the `serialize` and `deserialize` methods can be found in the [API](https://tessil.github.io/robin-map/classtsl_1_1robin__map.html).
+
+```c++
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <type_traits>
+#include <tsl/robin_map.h>
+
+
+class serializer {
+public:
+    serializer(const char* file_name) {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+        m_ostream.open(file_name, std::ios::binary);
+    }
+    
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void operator()(const T& value) {
+        m_ostream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+    
+    void operator()(const std::pair<std::int64_t, std::int64_t>& value) {
+        (*this)(value.first);
+        (*this)(value.second);
+    }
+
+private:
+    std::ofstream m_ostream;
+};
+
+class deserializer {
+public:
+    deserializer(const char* file_name) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+        m_istream.open(file_name, std::ios::binary);
+    }
+    
+    template<class T>
+    T operator()() {
+        T value;
+        deserialize(value);
+        
+        return value;
+    }
+    
+private:
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void deserialize(T& value) {
+        m_istream.read(reinterpret_cast<char*>(&value), sizeof(T));
+    }
+    
+    void deserialize(std::pair<std::int64_t, std::int64_t>& value) {
+        deserialize(value.first);
+        deserialize(value.second);
+    }
+
+private:
+    std::ifstream m_istream;
+};
+
+
+int main() {
+    const tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    
+    
+    const char* file_name = "robin_map.data";
+    {
+        serializer serial(file_name);
+        map.serialize(serial);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        auto map_deserialized = tsl::robin_map<std::int64_t, std::int64_t>::deserialize(dserial);
+        
+        assert(map == map_deserialized);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        
+        /**
+         * If the serialized and deserialized map are hash compatibles (see conditions in API), 
+         * setting the argument to true speed-up the deserialization process as we don't have 
+         * to recalculate the hash of each key. We also know how much space each bucket needs.
+         */
+        const bool hash_compatible = true;
+        auto map_deserialized = 
+            tsl::robin_map<std::int64_t, std::int64_t>::deserialize(dserial, hash_compatible);
+        
+        assert(map == map_deserialized);
+    }
+} 
+```
+
+##### Serialization with Boost Serialization and compression with zlib
+
+It is possible to use a serialization library to avoid the boilerplate. 
+
+The following example uses Boost Serialization with the Boost zlib compression stream to reduce the size of the resulting serialized file. The example requires C++20 due to the usage of the template parameter list syntax in lambdas, but it can be adapted to less recent versions.
+
+```c++
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/utility.hpp>
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <tsl/robin_map.h>
+
+
+namespace boost { namespace serialization {
+    template<class Archive, class Key, class T>
+    void serialize(Archive & ar, tsl::robin_map<Key, T>& map, const unsigned int version) {
+        split_free(ar, map, version); 
+    }
+
+    template<class Archive, class Key, class T>
+    void save(Archive & ar, const tsl::robin_map<Key, T>& map, const unsigned int /*version*/) {
+        auto serializer = [&ar](const auto& v) { ar & v; };
+        map.serialize(serializer);
+    }
+
+    template<class Archive, class Key, class T>
+    void load(Archive & ar, tsl::robin_map<Key, T>& map, const unsigned int /*version*/) {
+        auto deserializer = [&ar]<typename U>() { U u; ar & u; return u; };
+        map = tsl::robin_map<Key, T>::deserialize(deserializer);
+    }
+}}
+
+
+int main() {
+    tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    
+    
+    const char* file_name = "robin_map.data";
+    {
+        std::ofstream ofs;
+        ofs.exceptions(ofs.badbit | ofs.failbit);
+        ofs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_ostream fo;
+        fo.push(boost::iostreams::zlib_compressor());
+        fo.push(ofs);
+        
+        boost::archive::binary_oarchive oa(fo);
+        
+        oa << map;
+    }
+    
+    {
+        std::ifstream ifs;
+        ifs.exceptions(ifs.badbit | ifs.failbit | ifs.eofbit);
+        ifs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_istream fi;
+        fi.push(boost::iostreams::zlib_decompressor());
+        fi.push(ifs);
+        
+        boost::archive::binary_iarchive ia(fi);
+     
+        tsl::robin_map<std::int64_t, std::int64_t> map_deserialized;   
+        ia >> map_deserialized;
+        
+        assert(map == map_deserialized);
+    }
+}
+```
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ namespace boost { namespace serialization {
 
 
 int main() {
-    const tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
     
     
     const char* file_name = "robin_map.data";

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ To do so, it requires the user to provide a function object for both serializati
 
 ```c++
 struct serializer {
-    // Must support the following types for U: std::int16_t, `std::uint32_t, 
+    // Must support the following types for U: std::int16_t, std::uint32_t, 
     // std::uint64_t, float and std::pair<Key, T> if a map is used or Key for 
     // a set.
     template<typename U>
@@ -293,7 +293,7 @@ struct serializer {
 
 ```c++
 struct deserializer {
-    // Must support the following types for U: std::int16_t, `std::uint32_t, 
+    // Must support the following types for U: std::int16_t, std::uint32_t, 
     // std::uint64_t, float and std::pair<Key, T> if a map is used or Key for 
     // a set.
     template<typename U>

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ namespace boost { namespace serialization {
 
 
 int main() {
-    tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    const tsl::robin_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
     
     
     const char* file_name = "robin_map.data";

--- a/include/tsl/robin_growth_policy.h
+++ b/include/tsl/robin_growth_policy.h
@@ -67,6 +67,9 @@
 #endif
 
 
+#define TSL_RH_UNUSED(x) static_cast<void>(x)
+
+
 namespace tsl {
 namespace rh {
     

--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -89,8 +89,27 @@ static T numeric_cast(U value, const char* error_message = "numeric_cast() faile
     return ret;
 }
 
+template<class T, class Deserializer>
+static T deserialize_value(Deserializer& deserializer) {
+    // MSVC < 2017 is not conformant, circumvent the problem by removing the template keyword
+#if defined (_MSC_VER) && _MSC_VER < 1910
+    return deserializer.Deserializer::operator()<T>();
+#else
+    return deserializer.Deserializer::template operator()<T>();
+#endif
+}
 
-using truncated_hash_type = std::uint_least32_t;
+
+/**
+ * Fixed size type used to represent size_type values on serialization. Need to be big enough
+ * to represent a std::size_t on 32 and 64 bits platforms, and must be the same size on both platforms.
+ */
+using slz_size_type = std::uint64_t;
+static_assert(std::numeric_limits<slz_size_type>::max() >= std::numeric_limits<std::size_t>::max(),
+              "slz_size_type must be >= std::size_t");
+
+using truncated_hash_type = std::uint32_t;
+
 
 /**
  * Helper class that stores a truncated hash if StoreHash is true and nothing otherwise.
@@ -154,7 +173,7 @@ class bucket_entry: public bucket_entry_hash<StoreHash> {
     
 public:
     using value_type = ValueType;
-    using distance_type = std::int_least16_t;
+    using distance_type = std::int16_t;
     
     
     bucket_entry() noexcept: bucket_hash(), m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
@@ -275,12 +294,14 @@ public:
         swap(value, this->value());
         swap(dist_from_ideal_bucket, m_dist_from_ideal_bucket);
         
-        // Avoid warning of unused variable if StoreHash is false
-        (void) hash;
         if(StoreHash) {
             const truncated_hash_type tmp_hash = this->truncated_hash();
             this->set_hash(hash);
             hash = tmp_hash;
+        }
+        else {
+            // Avoid warning of unused variable if StoreHash is false
+            TSL_RH_UNUSED(hash);
         }
     }
     
@@ -295,14 +316,13 @@ private:
     }
 
 public:
+    static const distance_type EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET = -1;
     static const distance_type DIST_FROM_IDEAL_BUCKET_LIMIT = 4096;
     static_assert(DIST_FROM_IDEAL_BUCKET_LIMIT <= std::numeric_limits<distance_type>::max() - 1,
                  "DIST_FROM_IDEAL_BUCKET_LIMIT must be <= std::numeric_limits<distance_type>::max() - 1.");
     
 private:
     using storage = typename std::aligned_storage<sizeof(value_type), alignof(value_type)>::type;
-    
-    static const distance_type EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET = -1;
     
     distance_type m_dist_from_ideal_bucket;
     bool m_last_bucket;
@@ -393,8 +413,8 @@ private:
      * more bytes.
      */
     static bool USE_STORED_HASH_ON_REHASH(size_type bucket_count) {
-        (void) bucket_count;
         if(STORE_HASH && sizeof(std::size_t) == sizeof(truncated_hash_type)) {
+            TSL_RH_UNUSED(bucket_count);
             return true;
         }
         else if(STORE_HASH && is_power_of_two_policy<GrowthPolicy>::value) {
@@ -402,6 +422,7 @@ private:
             return (bucket_count - 1) <= std::numeric_limits<truncated_hash_type>::max();
         }
         else {
+            TSL_RH_UNUSED(bucket_count);
             return false;   
         }
     }
@@ -1118,6 +1139,16 @@ public:
         return iterator(const_cast<bucket_entry*>(pos.m_bucket));
     }
     
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        serialize_impl(serializer);
+    }
+    
+    template<class Deserializer>
+    void deserialize(Deserializer& deserializer, bool hash_compatible) {
+        deserialize_impl(deserializer, hash_compatible);
+    }
+    
 private:
     template<class K>
     std::size_t hash_key(const K& key) const {
@@ -1379,6 +1410,138 @@ private:
         
         return false;
     }
+    
+    template<class Serializer>
+    void serialize_impl(Serializer& serializer) const {
+        const slz_size_type version = SERIALIZATION_PROTOCOL_VERSION;
+        serializer(version);
+        
+        // Indicate if the truncated hash of each bucket is stored. Use a std::int16_t instead 
+        // of a bool to avoid the need for the serializer to support an extra 'bool' type.
+        const std::int16_t hash_stored_for_bucket = static_cast<std::int16_t>(STORE_HASH);
+        serializer(hash_stored_for_bucket);
+        
+        const slz_size_type nb_elements = m_nb_elements;
+        serializer(nb_elements);
+        
+        const slz_size_type bucket_count = m_buckets_data.size();
+        serializer(bucket_count);
+        
+        const float min_load_factor = m_min_load_factor;
+        serializer(min_load_factor);
+        
+        const float max_load_factor = m_max_load_factor;
+        serializer(max_load_factor);
+       
+        for(const bucket_entry& bucket: m_buckets_data) {
+            if(bucket.empty()) {
+                const std::int16_t empty_bucket = bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+                serializer(empty_bucket);
+            }
+            else {
+                const std::int16_t dist_from_ideal_bucket = bucket.dist_from_ideal_bucket();
+                serializer(dist_from_ideal_bucket);
+                if(STORE_HASH) {
+                    const std::uint32_t truncated_hash = bucket.truncated_hash();
+                    serializer(truncated_hash);
+                }
+                serializer(bucket.value());
+            }
+        }
+    }
+    
+    template<class Deserializer>
+    void deserialize_impl(Deserializer& deserializer, bool hash_compatible) {
+        tsl_rh_assert(m_buckets_data.empty()); // Current hash table must be empty
+        
+        const slz_size_type version = deserialize_value<slz_size_type>(deserializer);
+        // For now we only have one version of the serialization protocol. 
+        // If it doesn't match there is a problem with the file.
+        if(version != SERIALIZATION_PROTOCOL_VERSION) {
+            TSL_RH_THROW_OR_TERMINATE(std::runtime_error, "Can't deserialize the ordered_map/set. "
+                                                          "The protocol version header is invalid.");
+        }
+        
+        const bool hash_stored_for_bucket = deserialize_value<std::int16_t>(deserializer)?true:false;
+        if(hash_compatible && STORE_HASH != hash_stored_for_bucket) {
+            TSL_RH_THROW_OR_TERMINATE(std::runtime_error, "Can't deserialize a map with a different StoreHash "
+                                                           "than the one used during the serialization when "
+                                                           "hash compatibility is used");
+        }
+        
+        const slz_size_type nb_elements = deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type bucket_count_ds = deserialize_value<slz_size_type>(deserializer);
+        const float min_load_factor = deserialize_value<float>(deserializer);
+        const float max_load_factor = deserialize_value<float>(deserializer);
+        
+        if(min_load_factor < MINIMUM_MIN_LOAD_FACTOR || min_load_factor > MAXIMUM_MIN_LOAD_FACTOR) {
+            TSL_RH_THROW_OR_TERMINATE(std::runtime_error, "Invalid min_load_factor. Check that the serializer "
+                                                          "and deserializer support floats correctly as they "
+                                                          "can be converted implicitly to ints.");
+        }
+        
+        if(max_load_factor < MINIMUM_MAX_LOAD_FACTOR || max_load_factor > MAXIMUM_MAX_LOAD_FACTOR) {
+            TSL_RH_THROW_OR_TERMINATE(std::runtime_error, "Invalid max_load_factor. Check that the serializer "
+                                                          "and deserializer support floats correctly as they "
+                                                          "can be converted implicitly to ints.");
+        }
+        
+        this->min_load_factor(min_load_factor);
+        this->max_load_factor(max_load_factor);
+        
+        if(bucket_count_ds == 0) {
+            tsl_rh_assert(nb_elements == 0);
+            return;
+        }
+        
+        
+        if(!hash_compatible) {
+            reserve(numeric_cast<size_type>(nb_elements, "Deserialized nb_elements is too big."));
+            for(slz_size_type ibucket = 0; ibucket < bucket_count_ds; ibucket++) {
+                const distance_type dist_from_ideal_bucket = deserialize_value<std::int16_t>(deserializer);
+                if(dist_from_ideal_bucket != bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+                    if(hash_stored_for_bucket) {
+                        TSL_RH_UNUSED(deserialize_value<std::uint32_t>(deserializer));
+                    }
+                    
+                    insert(deserialize_value<value_type>(deserializer));
+                }
+            }
+            
+            tsl_rh_assert(nb_elements == size());
+        }
+        else {
+            m_bucket_count = numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big.");
+            
+            GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
+            // GrowthPolicy should not modify the bucket count we got from deserialization
+            if(m_bucket_count != bucket_count_ds) {
+                TSL_RH_THROW_OR_TERMINATE(std::runtime_error, "The GrowthPolicy is not the same even though hash_compatible is true.");
+            }
+            
+            m_nb_elements = numeric_cast<size_type>(nb_elements, "Deserialized nb_elements is too big.");
+            m_buckets_data.resize(m_bucket_count);
+            m_buckets = m_buckets_data.data();
+            
+            for(bucket_entry& bucket: m_buckets_data) {
+                const distance_type dist_from_ideal_bucket = deserialize_value<std::int16_t>(deserializer);
+                if(dist_from_ideal_bucket != bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+                    truncated_hash_type truncated_hash = 0;
+                    if(hash_stored_for_bucket) {
+                        tsl_rh_assert(hash_stored_for_bucket);
+                        truncated_hash = deserialize_value<std::uint32_t>(deserializer);
+                    }
+                    
+                    bucket.set_value_of_empty_bucket(dist_from_ideal_bucket, truncated_hash,
+                                                     deserialize_value<value_type>(deserializer));
+                }
+            }
+            
+            if(!m_buckets_data.empty()) {
+                m_buckets_data.back().set_as_last_bucket();
+            }
+        }
+    }
 
     
 public:
@@ -1400,6 +1563,11 @@ public:
                   "MAXIMUM_MIN_LOAD_FACTOR should be < MINIMUM_MAX_LOAD_FACTOR");
     
 private:
+    /**
+     * Protocol version currenlty used for serialization.
+     */
+    static const slz_size_type SERIALIZATION_PROTOCOL_VERSION = 1;
+
     /**
      * Return an always valid pointer to an static empty bucket_entry with last_bucket() == true.
      */            

--- a/include/tsl/robin_map.h
+++ b/include/tsl/robin_map.h
@@ -671,6 +671,48 @@ public:
         return m_ht.mutable_iterator(pos);
     }
     
+    /**
+     * Serialize the map through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `template<typename U> void operator()(const U& value);` where the types `std::int16_t`, `std::uint32_t`, 
+     *    `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+     * 
+     * The implementation leaves binary compatibility (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibility is required.
+     */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+    
+    /**
+     * Deserialize a previously serialized map through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following call:
+     *  - `template<typename U> U operator()();` where the types `std::int16_t`, `std::uint32_t`, `std::uint64_t`, `float` 
+     *    and `std::pair<Key, T>` must be supported for U.
+     * 
+     * If the deserialized hash map type is hash compatible with the serialized map, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized map and the StoreHash must have the same value. The `std::size_t` must also 
+     * be of the same size as the one on the platform used to serialize the map. If these criteria are not met, the behaviour is
+     * undefined with `hash_compatible` sets to true.
+     * 
+     * The behaviour is undefined if the type `Key` and `T` of the `robin_map` are not the same as the
+     * types used during serialization.
+     * 
+     * The implementation leaves binary compatibility (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibility is required.
+     */
+    template<class Deserializer>
+    static robin_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        robin_map map(0);
+        map.m_ht.deserialize(deserializer, hash_compatible);
+
+        return map;
+    }
+    
     friend bool operator==(const robin_map& lhs, const robin_map& rhs) {
         if(lhs.size() != rhs.size()) {
             return false;

--- a/include/tsl/robin_set.h
+++ b/include/tsl/robin_set.h
@@ -552,6 +552,47 @@ public:
         
         return true;
     }
+    
+    /**
+     * Serialize the set through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `template<typename U> void operator()(const U& value);` where the types `std::int16_t`, `std::uint32_t`, 
+     *    `std::uint64_t`, `float` and `Key` must be supported for U.
+     * 
+     * The implementation leaves binary compatibility (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibility is required.
+     */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+
+    /**
+     * Deserialize a previously serialized set through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following call:
+     *  - `template<typename U> U operator()();` where the types `std::int16_t`, `std::uint32_t`, `std::uint64_t`, `float` and 
+     *    `Key` must be supported for U.
+     * 
+     * If the deserialized hash set type is hash compatible with the serialized set, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized set and the StoreHash must have the same value. The `std::size_t` must also 
+     * be of the same size as the one on the platform used to serialize the set. If these criteria are not met, the behaviour is 
+     * undefined with `hash_compatible` sets to true.
+     *
+     * The behaviour is undefined if the type `Key` of the `robin_set` is not the same as the type used during serialization.
+     * 
+     * The implementation leaves binary compatibility (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibility is required.
+     */
+    template<class Deserializer>
+    static robin_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        robin_set set(0);
+        set.m_ht.deserialize(deserializer, hash_compatible);
+
+        return set;
+    }
 
     friend bool operator!=(const robin_set& lhs, const robin_set& rhs) {
         return !operator==(lhs, rhs);
@@ -579,4 +620,3 @@ using robin_pg_set = robin_set<Key, Hash, KeyEqual, Allocator, StoreHash, tsl::r
 } // end namespace tsl
 
 #endif
- 

--- a/tests/robin_set_tests.cpp
+++ b/tests/robin_set_tests.cpp
@@ -140,5 +140,38 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
     BOOST_CHECK_EQUAL(set.size(), 1);
     BOOST_CHECK_EQUAL(**set.begin(), value);
 }
+    
+/**
+ * serialize and deserialize
+ */
+BOOST_AUTO_TEST_CASE(test_serialize_deserialize) {
+    // insert x values; delete some values; serialize set; deserialize in new set; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const std::size_t nb_values = 1000;
+    
+    
+    tsl::robin_set<move_only_test> set;
+    for(std::size_t i = 0; i < nb_values + 40; i++) {
+        set.insert(utils::get_key<move_only_test>(i));
+    }
+    
+    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+        set.erase(utils::get_key<move_only_test>(i));
+    }
+    BOOST_CHECK_EQUAL(set.size(), nb_values);
+
+    
+    
+    serializer serial;
+    set.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto set_deserialized = decltype(set)::deserialize(dserial, true);
+    BOOST_CHECK(set == set_deserialized);
+
+    deserializer dserial2(serial.str());
+    set_deserialized = decltype(set)::deserialize(dserial2, false);
+    BOOST_CHECK(set_deserialized == set);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -118,6 +118,9 @@ public:
     explicit move_only_test(std::int64_t value) : m_value(new std::string(std::to_string(value))) {
     }
     
+    explicit move_only_test(std::string value) : m_value(new std::string(std::move(value))) {
+    }
+    
     move_only_test(const move_only_test&) = delete;
     move_only_test(move_only_test&&) = default;
     move_only_test& operator=(const move_only_test&) = delete;
@@ -256,6 +259,11 @@ public:
 
 
 template<>
+inline std::int32_t utils::get_key<std::int32_t>(std::size_t counter) {
+    return tsl::detail_robin_hash::numeric_cast<std::int32_t>(counter);
+}
+
+template<>
 inline std::int64_t utils::get_key<std::int64_t>(std::size_t counter) {
     return tsl::detail_robin_hash::numeric_cast<std::int64_t>(counter);
 }
@@ -282,6 +290,11 @@ inline copy_only_test utils::get_key<copy_only_test>(std::size_t counter) {
 
 
 
+
+template<>
+inline std::int32_t utils::get_value<std::int32_t>(std::size_t counter) {
+    return tsl::detail_robin_hash::numeric_cast<std::int32_t>(counter*2);
+}
 
 template<>
 inline std::int64_t utils::get_value<std::int64_t>(std::size_t counter) {
@@ -323,5 +336,109 @@ inline HMap utils::get_filled_hash_map(std::size_t nb_elements) {
     
     return map;
 }
+
+
+
+template<class T>
+struct is_pair: std::false_type {
+};
+
+template <class T1, class T2>
+struct is_pair<std::pair<T1, T2>>: std::true_type {
+};
+
+/**
+ * serializer helper to test serialize(...) and deserialize(...) functions
+ */
+class serializer {
+public:
+    serializer() {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+    }
+    
+    template<class T>
+    void operator()(const T& val) {
+        serialize_impl(val);
+    }
+    
+    std::string str() const {
+        return m_ostream.str();
+    }
+    
+private:
+    template<typename T, typename U>
+    void serialize_impl(const std::pair<T, U>& val) {
+        serialize_impl(val.first);
+        serialize_impl(val.second);
+    }
+    
+    void serialize_impl(const std::string& val) {
+        serialize_impl(tsl::detail_robin_hash::numeric_cast<std::uint64_t>(val.size()));
+        m_ostream.write(val.data(), val.size());
+    }
+
+    void serialize_impl(const move_only_test& val) {
+        serialize_impl(val.value());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void serialize_impl(const T& val) {
+        m_ostream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+    
+private:
+    std::stringstream m_ostream;
+};
+
+class deserializer {
+public:
+    explicit deserializer(const std::string& init_str = ""): m_istream(init_str) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+    }
+    
+    template<class T>
+    T operator()() {
+        return deserialize_impl<T>();
+    }
+
+private:
+    template<class T, 
+             typename std::enable_if<is_pair<T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        auto first = deserialize_impl<typename T::first_type>();
+        return std::make_pair(std::move(first), deserialize_impl<typename T::second_type>());
+    }
+    
+    template<class T, 
+             typename std::enable_if<std::is_same<std::string, T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        const std::size_t str_size = tsl::detail_robin_hash::numeric_cast<std::size_t>(deserialize_impl<std::uint64_t>());
+        
+        // TODO std::string::data() return a const pointer pre-C++17. Avoid the inefficient double allocation.
+        std::vector<char> chars(str_size);
+        m_istream.read(chars.data(), str_size);
+        
+        return std::string(chars.data(), chars.size());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_same<move_only_test, T>::value>::type* = nullptr>
+    move_only_test deserialize_impl() {
+        return move_only_test(deserialize_impl<std::string>());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        T val;
+        m_istream.read(reinterpret_cast<char*>(&val), sizeof(val));
+
+        return val;
+    }
+    
+private:
+    std::stringstream m_istream;
+};
 
 #endif


### PR DESCRIPTION
This PR adds two new methods `template<class Serializer> void serialize(Serializer& serializer) const;` and `template<class Deserializer> static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false);` to `tsl::robin_(pg)_map/set`. 

They take advantage of the internals of the data structure to provide an efficient way to serialize/deserialize the structure.

Fix feature request #28.