### PR TITLE
add support for heterogeneous insert

### DIFF
--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -1281,7 +1281,6 @@ private:
         return std::make_pair(iterator(m_buckets + ibucket), true);
     }
     
-    
     template<class... Args>
     void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket, 
                       truncated_hash_type hash, Args&&... value_type_args) 
@@ -1295,6 +1294,13 @@ private:
     {
         insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
     }
+
+    void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                      truncated_hash_type hash, key_equal&& value)
+    {
+        insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value_type(value));
+    }
+
 
     /*
      * We don't use `value_type&& value` as last argument due to a bug in MSVC when `value_type` is a pointer,

--- a/include/tsl/robin_set.h
+++ b/include/tsl/robin_set.h
@@ -89,12 +89,14 @@ private:
     class KeySelect {
     public:
         using key_type = Key;
-        
-        const key_type& operator()(const Key& key) const noexcept {
+
+        template<class K>
+        const K& operator()(const K& key) const noexcept {
             return key;
         }
         
-        key_type& operator()(Key& key) noexcept {
+        template<class K>
+        K& operator()(K& key) noexcept {
             return key;
         }
     };
@@ -233,8 +235,55 @@ public:
     void clear() noexcept { m_ht.clear(); }
     
     
-    
-    
+
+    template<
+        class K,
+        class KE = KeyEqual,
+        typename std::enable_if<
+            has_is_transparent<KE>::value &&
+            std::is_constructible<key_type, K>::value
+        >::type* = nullptr
+    >
+    std::pair<iterator, bool> insert(const K& value) { 
+        return m_ht.insert(value); 
+    }
+
+    template<
+        class K,
+        class KE = KeyEqual,
+        typename std::enable_if<
+            has_is_transparent<KE>::value &&
+            std::is_constructible<key_type, K>::value
+        >::type* = nullptr
+    >
+    std::pair<iterator, bool> insert(K&& value) { 
+        return m_ht.insert(std::move(value)); 
+    }
+
+    template<
+        class K,
+        class KE = KeyEqual,
+        typename std::enable_if<
+            has_is_transparent<KE>::value &&
+            std::is_constructible<key_type, K>::value
+        >::type* = nullptr
+    >
+    iterator insert(const_iterator hint, const K& value) { 
+        return m_ht.insert_hint(hint, value); 
+    }
+
+    template<
+        class K,
+        class KE = KeyEqual,
+        typename std::enable_if<
+            has_is_transparent<KE>::value &&
+            std::is_constructible<key_type, K>::value
+        >::type* = nullptr
+    >
+    iterator insert(const_iterator hint, K&& value) { 
+        return m_ht.insert_hint(hint, std::move(value)); 
+    }
+
     std::pair<iterator, bool> insert(const value_type& value) { 
         return m_ht.insert(value); 
     }
@@ -250,7 +299,7 @@ public:
     iterator insert(const_iterator hint, value_type&& value) { 
         return m_ht.insert_hint(hint, std::move(value)); 
     }
-    
+
     template<class InputIt>
     void insert(InputIt first, InputIt last) { 
         m_ht.insert(first, last);


### PR DESCRIPTION
This pull request adds support for heterogeneous. This is useful for the same reasons as heterogeneous lookup. You can for example insert words from a string into a set of strings, without unnecessary memory allocations (see example).

In addition to the requirements for heterogeneous lookup the "key" type has to be constructible from the "key_equal" type.
I strongly recommend using an explicit constructor otherwise you always live in danger of silent copys.

The changes required for this to work are very minor, because most of the code is already generic.

Right now it's only implemented for robin_set and not tested throughoutly, because i want to know what you think about it before i waste my time.

[example.cpp.txt](https://github.com/Tessil/robin-map/files/5471938/example.cpp.txt)