### PR TITLE
Replace depecrated std::aligned_storage since C++23 by alignas

### DIFF
--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -331,8 +331,7 @@ class bucket_entry : public bucket_entry_hash<StoreHash> {
                 "std::numeric_limits<distance_type>::max() - 1.");
 
  private:
-  using storage = typename std::aligned_storage<sizeof(value_type),
-                                                alignof(value_type)>::type;
+  using storage = alignas(value_type) unsigned char[sizeof(value_type)];
 
   distance_type m_dist_from_ideal_bucket;
   bool m_last_bucket;

--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -331,11 +331,9 @@ class bucket_entry : public bucket_entry_hash<StoreHash> {
                 "std::numeric_limits<distance_type>::max() - 1.");
 
  private:
-  using storage = alignas(value_type) unsigned char[sizeof(value_type)];
-
   distance_type m_dist_from_ideal_bucket;
   bool m_last_bucket;
-  storage m_value;
+  alignas(value_type) unsigned char m_value[sizeof(value_type)];
 };
 
 /**


### PR DESCRIPTION
Replace the deprecated `std::aligned_storage` usage in the library by `alignas` to be compatible with C++23.

Fix issue #57