### PR TITLE
Add a CMake TSL_ROBIN_MAP_ENABLE_INSTALL option to explicity enable/disable the install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ project(tsl-robin-map VERSION 1.2.1 LANGUAGES CXX)
 include(GNUInstallDirs)
 
 
+set(IS_MAIN_PROJECT FALSE)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(IS_MAIN_PROJECT TRUE)
+endif()
+
+# Enable the install target if the project is used main project (disable by default if subproject)
+option(TSL_ROBIN_MAP_ENABLE_INSTALL "Enable install target" ${IS_MAIN_PROJECT})
+
+
 add_library(robin_map INTERFACE)
 # Use tsl::robin_map as target, more consistent with other libraries conventions (Boost, Qt, ...)
 add_library(tsl::robin_map ALIAS robin_map)
@@ -25,16 +34,8 @@ if(MSVC)
                    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_DATAROOTDIR}/tsl-robin-map.natvis>")
 endif()
 
-
-
-
-set(IS_SUBPROJECT TRUE)
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-  set(IS_SUBPROJECT FALSE)
-endif()
-
 # Installation
-if(NOT IS_SUBPROJECT)
+if(TSL_ROBIN_MAP_ENABLE_INSTALL)
     include(CMakePackageConfigHelpers)
 
     ## Install include directory and potential natvis file


### PR DESCRIPTION
Add a CMake `TSL_ROBIN_MAP_ENABLE_INSTALL` option to explicitly enable/disable the install target.

The option is OFF by default when robin-map is used as subproject.

Fix issue #66 