### PR TITLE
Specify library version as part of the headers

### DIFF
--- a/include/tsl/robin_growth_policy.h
+++ b/include/tsl/robin_growth_policy.h
@@ -35,6 +35,13 @@
 #include <ratio>
 #include <stdexcept>
 
+// A change of the major version indicates an API and/or ABI break (change of in-memory layout of the data structure)
+#define TSL_RH_VERSION_MAJOR 1
+// A change of the minor version indicates the addition of a feature without impact on the API/ABI
+#define TSL_RH_VERSION_MINOR 2
+// A change of the patch version indicates a bugfix without additional functionality
+#define TSL_RH_VERSION_PATCH 1
+
 #ifdef TSL_DEBUG
 #define tsl_rh_assert(expr) assert(expr)
 #else


### PR DESCRIPTION
Dear @Tessil,

would you consider specifying the robin-map version as part of the header files?

I am the author of [nanobind](https://github.com/wjakob/nanobind), a Python <-> C++ binding layer that uses robin-map in various internal data structures. Robin-map has been great, I am really happy with both design and performance.

nanobind pins a specific version of robin-map to ensure ABI compatibility. That way, multiple separately compiled C++ extensions can pool their internal data structures to exchange information about types and objects.

But one issue now that nanobind is being used by more people and different distributions is that they really don't like having a pinned dependency. They want to use the latest one available on the OS or package manager. That introduces the possibility of ABI contract violations.

Having an easily queriable `#define` as part of the robin map headers would make it easier to catch such future changes (perhaps unlikely, as this seems like a relatively stable project, but one can never be sure)