### PR TITLE
Fix load threshold on deserialization

### DIFF
--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -1468,6 +1468,9 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     } else {
       m_bucket_count = numeric_cast<size_type>(
           bucket_count_ds, "Deserialized bucket_count is too big.");
+      // Recompute m_load_threshold, during max_load_factor() the bucket count
+      // was still 0 which would trigger rehash on first insert
+      m_load_threshold = size_type(float(bucket_count()) * m_max_load_factor);
 
       GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
       // GrowthPolicy should not modify the bucket count we got from


### PR DESCRIPTION
The current version computes load using max_load_factor() without first setting m_bucket_count (default 0) leading to threshold 0, which triggers rehash (and size increase) on first insert.

Recompute the threshold after setting correct bucket count to avoid this.