### PR TITLE
Do not use `else` after `return`

### DIFF
--- a/include/tsl/robin_growth_policy.h
+++ b/include/tsl/robin_growth_policy.h
@@ -221,9 +221,8 @@ class mod_growth_policy {
 
     if (next_bucket_count > double(max_bucket_count())) {
       return max_bucket_count();
-    } else {
-      return std::size_t(next_bucket_count);
     }
+    return std::size_t(next_bucket_count);
   }
 
   std::size_t max_bucket_count() const { return MAX_BUCKET_COUNT; }

--- a/include/tsl/robin_hash.h
+++ b/include/tsl/robin_hash.h
@@ -408,14 +408,14 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     if (STORE_HASH && sizeof(std::size_t) == sizeof(truncated_hash_type)) {
       TSL_RH_UNUSED(bucket_count);
       return true;
-    } else if (STORE_HASH && is_power_of_two_policy<GrowthPolicy>::value) {
+    }
+    if (STORE_HASH && is_power_of_two_policy<GrowthPolicy>::value) {
       return bucket_count == 0 ||
              (bucket_count - 1) <=
                  std::numeric_limits<truncated_hash_type>::max();
-    } else {
-      TSL_RH_UNUSED(bucket_count);
-      return false;
     }
+    TSL_RH_UNUSED(bucket_count);
+    return false;
   }
 
   using bucket_entry =
@@ -863,9 +863,8 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     if (it != end()) {
       erase_from_bucket(it);
       return 1;
-    } else {
-      return 0;
     }
+    return 0;
   }
 
   void swap(robin_hash& other) {
@@ -913,9 +912,8 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     auto it = find(key, hash);
     if (it != cend()) {
       return it.value();
-    } else {
-      TSL_RH_THROW_OR_TERMINATE(std::out_of_range, "Couldn't find key.");
     }
+    TSL_RH_THROW_OR_TERMINATE(std::out_of_range, "Couldn't find key.");
   }
 
   template <class K, class U = ValueSelect,
@@ -933,9 +931,8 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
   size_type count(const K& key, std::size_t hash) const {
     if (find(key, hash) != cend()) {
       return 1;
-    } else {
-      return 0;
     }
+    return 0;
   }
 
   template <class K>
@@ -1308,10 +1305,9 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
           m_buckets[ibucket].set_value_of_empty_bucket(dist_from_ideal_bucket,
                                                        hash, std::move(value));
           return;
-        } else {
-          m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
-                                                       hash, value);
         }
+        m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
+                                                     hash, value);
       }
 
       dist_from_ideal_bucket++;

--- a/tests/robin_map_tests.cpp
+++ b/tests/robin_map_tests.cpp
@@ -1224,9 +1224,8 @@ BOOST_AUTO_TEST_CASE(test_key_equal) {
     std::size_t operator()(std::uint64_t v) const {
       if (v % 2u == 1u) {
         return std::hash<std::uint64_t>()(v - 1);
-      } else {
-        return std::hash<std::uint64_t>()(v);
       }
+      return std::hash<std::uint64_t>()(v);
     }
   };
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -152,9 +152,8 @@ class move_only_test {
   friend bool operator==(const move_only_test& lhs, const move_only_test& rhs) {
     if (lhs.m_value == nullptr || rhs.m_value == nullptr) {
       return lhs.m_value == nullptr && rhs.m_value == nullptr;
-    } else {
-      return *lhs.m_value == *rhs.m_value;
     }
+    return *lhs.m_value == *rhs.m_value;
   }
 
   friend bool operator!=(const move_only_test& lhs, const move_only_test& rhs) {
@@ -164,13 +163,14 @@ class move_only_test {
   friend bool operator<(const move_only_test& lhs, const move_only_test& rhs) {
     if (lhs.m_value == nullptr && rhs.m_value == nullptr) {
       return false;
-    } else if (lhs.m_value == nullptr) {
-      return true;
-    } else if (rhs.m_value == nullptr) {
-      return false;
-    } else {
-      return *lhs.m_value < *rhs.m_value;
     }
+    if (lhs.m_value == nullptr) {
+      return true;
+    }
+    if (rhs.m_value == nullptr) {
+      return false;
+    }
+    return *lhs.m_value < *rhs.m_value;
   }
 
   const std::string& value() const { return *m_value; }


### PR DESCRIPTION
Changes automatically done via:
```
run-clang-tidy-20 -header-filter=.* -checks=readability-else-after-return -fix
```