### PR TITLE
Raise CMake minimum version to 3.10..3.31 range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10...3.31)
 
 project(tsl-robin-map VERSION 1.4.0 LANGUAGES CXX)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10...3.31)
 
 project(tsl_robin_map_tests)
 


### PR DESCRIPTION
CMake 3.10 was released in 2017.

Amends 1115dad3ffa0994e3f43b693d9b9cc99944c64c1, fixes warning since CMake-3.31:

CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required): Compatibility with CMake < 3.10 will be removed from a future version of CMake.

Update the VERSION argument value. Or, use the ... syntax to tell CMake that the project requires at least but has been updated to work with policies introduced by or earlier.